### PR TITLE
Fix compile with gcc-14.1.0

### DIFF
--- a/szap-s2.c
+++ b/szap-s2.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <time.h>
 #include <unistd.h>
+#include <ctype.h>
 
 #include <stdint.h>
 #include <sys/time.h>

--- a/tzap-t2.c
+++ b/tzap-t2.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <time.h>
 #include <unistd.h>
+#include <ctype.h>
 
 #include <stdint.h>
 #include <sys/time.h>


### PR DESCRIPTION
szap-s2.c: In function 'read_channels':
tzap-t2.c: In function 'read_channels':
tzap-t2.c:710:33: error: implicit declaration of function 'toupper' [-Wimplicit-function-declaration]
  710 |                         switch (toupper(*field)) {
      |                                 ^~~~~~~
szap-s2.c:734:33: error: implicit declaration of function 'toupper' [-Wimplicit-function-declaration]
  734 |                         switch (toupper(*field)) {
      |                                 ^~~~~~~
tzap-t2.c:45:1: note: include '<ctype.h>' or provide a declaration of 'toupper'
   44 | #include "lnb.h"
  +++ |+#include <ctype.h>
   45 |
szap-s2.c:45:1: note: include '<ctype.h>' or provide a declaration of 'toupper'
   44 | #include "lnb.h"
  +++ |+#include <ctype.h>
   45 |
make: *** [Makefile:37: szap-s2.o] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:37: tzap-t2.o] Error 1